### PR TITLE
change to_json method for product to use binary_url instead of raw Obj

### DIFF
--- a/app/models/rich_snippet/product.rb
+++ b/app/models/rich_snippet/product.rb
@@ -19,7 +19,7 @@ module RichSnippet
         "@context": "http://schema.org/",
         "@type": "Product",
         name: name,
-        image: image,
+        image: image ? image.binary_url : '',
         description: description,
         mpn: mpn,
         award: awards,


### PR DESCRIPTION
Not sure what the initial motivation for the original line was (also maybe just oversight). But without this change the produced output is not valid.
<img width="783" alt="Screen Shot 2019-04-04 at 14 32 16" src="https://user-images.githubusercontent.com/31699194/55560689-10c58d00-56f1-11e9-8eff-dee99ed4d943.png">
